### PR TITLE
Implement email verification endpoints

### DIFF
--- a/src/main/java/com/example/point_career/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/point_career/domain/user/controller/UserController.java
@@ -38,20 +38,20 @@ public class UserController {
 	}
 
 	// BE-2 이메일 인증 코드 요청
-	@Operation(summary = "이메일 인증 코드 요청")
-	@PostMapping("/email/code/request")
-	public BaseResponse<EmailCodeResponse> requestEmailCode(@RequestBody EmailCodeRequest request) {
-		// TODO: 인증코드 생성 및 발송
-		return null;
-	}
+        @Operation(summary = "이메일 인증 코드 요청")
+        @PostMapping("/email/code/request")
+        public BaseResponse<EmailCodeResponse> requestEmailCode(@RequestBody EmailCodeRequest request) {
+                return new BaseResponse<>(BaseResponseStatus.EMAIL_CODE_SENT_SUCCESS,
+                                userService.requestEmailCode(request));
+        }
 
 	// BE-3 이메일 인증 코드 검증
-	@Operation(summary = "이메일 인증 코드 검증")
-	@PostMapping("/email/code/verify")
-	public BaseResponse<EmailCodeVerifyResponse> verifyEmailCode(@RequestBody EmailCodeVerifyRequest request) {
-		// TODO: 인증코드 검증 및 인증 처리
-		return null;
-	}
+        @Operation(summary = "이메일 인증 코드 검증")
+        @PostMapping("/email/code/verify")
+        public BaseResponse<EmailCodeVerifyResponse> verifyEmailCode(@RequestBody EmailCodeVerifyRequest request) {
+                return new BaseResponse<>(BaseResponseStatus.EMAIL_VERIFY_SUCCESS,
+                                userService.verifyEmailCode(request));
+        }
 
 	// BE-4 로그인
 	@Operation(summary = "로그인")

--- a/src/main/java/com/example/point_career/domain/user/entity/EmailCode.java
+++ b/src/main/java/com/example/point_career/domain/user/entity/EmailCode.java
@@ -1,0 +1,24 @@
+package com.example.point_career.domain.user.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@Setter
+@RedisHash(value = "emailCode")
+public class EmailCode {
+    @Id
+    private String email;
+    private String code;
+    @TimeToLive
+    private Long expirationTime;
+
+    public EmailCode(String email, String code, Long expirationTime) {
+        this.email = email;
+        this.code = code;
+        this.expirationTime = expirationTime;
+    }
+}

--- a/src/main/java/com/example/point_career/domain/user/repository/EmailCodeRepository.java
+++ b/src/main/java/com/example/point_career/domain/user/repository/EmailCodeRepository.java
@@ -1,0 +1,9 @@
+package com.example.point_career.domain.user.repository;
+
+import com.example.point_career.domain.user.entity.EmailCode;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmailCodeRepository extends CrudRepository<EmailCode, String> {
+}

--- a/src/main/java/com/example/point_career/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/point_career/domain/user/repository/UserRepository.java
@@ -8,9 +8,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-	Optional<User> findByLoginId(String loginId);
+        Optional<User> findByLoginId(String loginId);
+        Optional<User> findByEmail(String email);
 
-	boolean existsByEmail(String email);
+        boolean existsByEmail(String email);
 
-	boolean existsByLoginId(String loginId);
+        boolean existsByLoginId(String loginId);
 }

--- a/src/main/java/com/example/point_career/global/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/example/point_career/global/common/response/BaseResponseStatus.java
@@ -11,7 +11,9 @@ public enum BaseResponseStatus {
 	 */
 	SUCCESS("success", 20000, "요청에 성공했습니다."),
 	LOGIN_SUCCESS("success",20001,"로그인에 성공했습니다."),
-	REGISTER_SUCCESS("success",20002,"회원가입에 성공했습니다."),
+        REGISTER_SUCCESS("success",20002,"회원가입에 성공했습니다."),
+        EMAIL_CODE_SENT_SUCCESS("success",20003,"인증 코드 발송 완료"),
+        EMAIL_VERIFY_SUCCESS("success",20004,"이메일 인증 완료"),
 
 	/**
 	 * 400xx : Bad Request
@@ -19,7 +21,8 @@ public enum BaseResponseStatus {
 	FAIL("fail", 40000, "요청에 실패했습니다."),
 	VALIDATION_ERROR("fail", 40001, "유효성 검사에 실패했습니다."),
 	PASSWORD_ERROR("fail", 40002, "유효하지 않은 비밀번호입니다."),
-	PASSWORDS_DO_NOT_MATCH("fail", 40003, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+        PASSWORDS_DO_NOT_MATCH("fail", 40003, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+        EMAIL_CODE_INVALID("fail", 40004, "인증 코드가 올바르지 않습니다."),
 
 	/**
 	 * 401xx : Unauthorized
@@ -35,7 +38,8 @@ public enum BaseResponseStatus {
 	 * 404xx : Not Found
 	 */
 	//User
-	USER_NOT_EXIST("fail", 40401, "존재하지 않는 회원입니다."),
+        USER_NOT_EXIST("fail", 40401, "존재하지 않는 회원입니다."),
+        EMAIL_NOT_EXIST("fail", 40402, "등록되지 않은 이메일입니다."),
 
 	/**
 	 * 409xx : Conflict


### PR DESCRIPTION
## Summary
- add redis entity `EmailCode` and repository
- extend `UserRepository` with `findByEmail`
- define new response statuses for email verification
- implement request/verify email code logic in service and controller

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684438e90c508329a4ab51a6b9e85c07